### PR TITLE
Use compressed dataset files

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -6,8 +6,8 @@ expectations:
 actions:
 
   generate_dataset:
-    run: ehrql:v0 generate-dataset analysis/dataset_definition.py --output output/dataset.csv
+    run: ehrql:v0 generate-dataset analysis/dataset_definition.py --output output/dataset.csv.gz
     outputs:
       highly_sensitive:
-        cohort: output/dataset.csv
+        cohort: output/dataset.csv.gz
 


### PR DESCRIPTION
The initial example project.yaml used plain csvs which can be quite large, [as a general rule we ask users to use compressed formats](https://docs.opensafely.org/ehrql/explanation/output-formats/) to help keep server disk usage to a minimum.

This PR suggest `.csv.gz`  although `.arrow` is an equally valid option (perhaps even better as there are VS Code extensions for viewing `.arrow` files).