### PR TITLE
Update `ons_deaths` table

### DIFF
--- a/analysis/dataset_definition.py
+++ b/analysis/dataset_definition.py
@@ -51,9 +51,8 @@ dataset.vte_count_primary_diagnoses = vte_primary_events.count_for_patient()
 
 # vte deaths
 dataset.has_died = ons_deaths.exists_for_patient()
-most_recent_death_date = ons_deaths.sort_by(ons_deaths.date).last_for_patient()
-dataset.date_of_death = most_recent_death_date.date
-dataset.age_at_death = patients.age_on(most_recent_death_date.date)
+dataset.date_of_death = ons_deaths.date
+dataset.age_at_death = patients.age_on(ons_deaths.date)
 
 # age and sex
 dataset.age_at_last_vte = patients.age_on(most_recent_vte_primary.date)


### PR DESCRIPTION
The `ons_deaths` table is now a `PatientFrame` (with one row per patient) so it is no longer needed to select one event per patient. The ons_deaths table now includes the earliest registered death for each patient. Only very few patients have multiple registered deaths so this change is very unlikely to impact the results of the study.

Also note that, although the variable in your code was named `most_recent_death_date`, you actually selected the latests registered death using `.last_for_patient()`. But as mentioned above, this is very unlikely to impact the results of the study. 