### PR TITLE
Include CTV3 code descriptions in pivoted output

### DIFF
--- a/analysis/aggregate_pivots.py
+++ b/analysis/aggregate_pivots.py
@@ -6,7 +6,8 @@ def redact(x):
 
 
 dataset = pd.read_csv("output/dataset_pivoted.csv.gz")
-
+ctv3codes = pd.read_csv("codelists/opensafely-venous-thromboembolic-disease.csv")
+ctv3codes = ctv3codes[["CTV3Code", "CTV3PreferredTermDesc"]].drop_duplicates()
 vte_code_cols = [
     c
     for c in dataset.columns
@@ -17,4 +18,5 @@ results = {c: dataset[c].value_counts() for c in vte_code_cols}
 
 for vte_column, code_counts in results.items():
     code_counts = code_counts.apply(redact)
-    code_counts.to_csv(f"output/{vte_column}.csv", header=False, index=True)
+    code_counts = ctv3codes.merge(code_counts, right_index=True, left_on="CTV3Code")
+    code_counts.to_csv(f"output/{vte_column}.csv", header=True, index=False)


### PR DESCRIPTION
make it easier to interpret VTE coding journey by including CTV description field in outputs